### PR TITLE
ci: use Go 1.10/1.11, test with -race

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
-  - 1.9.3
-  - 1.8.6
-script: go test -v ./... -check.vv
+  - 1.10.x
+  - 1.11.x
+script: go test -v -check.vv -race ./...
 sudo: false
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ version: '{build}'
 build: false
 deploy: false
 
-clone_folder: 'c:\gopath\src\github.com\theckman\go-flock'
+clone_folder: 'c:\gopath\src\github.com\gofrs\flock'
 
 environment:
   GOPATH: 'c:\gopath'
-  GOVERSION: '1.9.2'
+  GOVERSION: '1.11'
 
 init:
   - git config --global core.autocrlf input
@@ -22,4 +22,4 @@ install:
 
 test_script:
   - go get -t ./...
-  - go test -v ./...
+  - go test -race -v ./...


### PR DESCRIPTION
Noticed when looking over this project for https://github.com/gofrs/help-requests/issues/26