### PR TITLE
Update README to replace references to theckman/go-flock

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# go-flock
-[![TravisCI Build Status](https://img.shields.io/travis/theckman/go-flock/master.svg?style=flat)](https://travis-ci.org/theckman/go-flock)
-[![GoDoc](https://img.shields.io/badge/godoc-go--flock-blue.svg?style=flat)](https://godoc.org/github.com/theckman/go-flock)
-[![License](https://img.shields.io/badge/license-BSD_3--Clause-brightgreen.svg?style=flat)](https://github.com/theckman/go-flock/blob/master/LICENSE)
+# flock
+[![TravisCI Build Status](https://img.shields.io/travis/gofrs/flock/master.svg?style=flat)](https://travis-ci.org/gofrs/flock)
+[![GoDoc](https://img.shields.io/badge/godoc-go--flock-blue.svg?style=flat)](https://godoc.org/github.com/gofrs/flock)
+[![License](https://img.shields.io/badge/license-BSD_3--Clause-brightgreen.svg?style=flat)](https://github.com/gofrs/flock/blob/master/LICENSE)
 
 `flock` implements a thread-safe sync.Locker interface for file locking. It also
 includes a non-blocking TryLock() function to allow locking without blocking execution.
@@ -15,12 +15,12 @@ package has an implicit dependency on Go 1.7+.
 
 ## Installation
 ```
-go get -u github.com/theckman/go-flock
+go get -u github.com/gofrs/flock
 ```
 
 ## Usage
 ```Go
-import "github.com/theckman/go-flock"
+import "github.com/gofrs/flock"
 
 fileLock := flock.NewFlock("/var/lock/go-lock.lock")
 
@@ -37,4 +37,4 @@ if locked {
 ```
 
 For more detailed usage information take a look at the package API docs on
-[GoDoc](https://godoc.org/github.com/theckman/go-flock).
+[GoDoc](https://godoc.org/github.com/gofrs/flock).


### PR DESCRIPTION
This is one of the final steps needed to complete the migration to the Gofrs
organization.

Signed-off-by: Tim Heckman <t@heckman.io>