### PR TITLE
don't mention sync.Locker in package documentation

### DIFF
--- a/flock.go
+++ b/flock.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
-// Package flock implements a thread-safe sync.Locker interface for file locking.
+// Package flock implements a thread-safe interface for file locking.
 // It also includes a non-blocking TryLock() function to allow locking
 // without blocking execution.
 //


### PR DESCRIPTION
(*Flock).Lock and (*Flock).Unlock return errors, unlike the Lock and
Unlock methods specified by sync.Locker. Therefore, don't mention
sync.Locker in package-level documentation, to avoid confusion.

Fixes #33.