### PR TITLE
feat: add directory support

### DIFF
--- a/flock.go
+++ b/flock.go
@@ -19,7 +19,6 @@ package flock
 import (
 	"context"
 	"os"
-	"runtime"
 	"sync"
 	"time"
 )
@@ -112,27 +111,6 @@ func tryCtx(ctx context.Context, fn func() (bool, error), retryDelay time.Durati
 			// try again
 		}
 	}
-}
-
-func (f *Flock) setFh() error {
-	// open a new os.File instance
-	// create it if it doesn't exist, and open the file read-only.
-	flags := os.O_CREATE
-	if runtime.GOOS == "aix" {
-		// AIX cannot preform write-lock (ie exclusive) on a
-		// read-only file.
-		flags |= os.O_RDWR
-	} else {
-		flags |= os.O_RDONLY
-	}
-	fh, err := os.OpenFile(f.path, flags, os.FileMode(0600))
-	if err != nil {
-		return err
-	}
-
-	// set the filehandle on the struct
-	f.fh = fh
-	return nil
 }
 
 // ensure the file handle is closed if no lock is held

--- a/flock_aix.go
+++ b/flock_aix.go
@@ -269,3 +269,19 @@ func setlkw(fd uintptr, lt lockType) error {
 		}
 	}
 }
+
+func (f *Flock) setFh() error {
+	// open a new os.File instance
+	// create it if it doesn't exist, and open the file read-only.
+	// AIX cannot preform write-lock (ie exclusive) on a
+	// read-only file.
+	flags := os.O_CREATE | os.O_RDWR
+	fh, err := os.OpenFile(f.path, flags, os.FileMode(0600))
+	if err != nil {
+		return err
+	}
+
+	// set the filehandle on the struct
+	f.fh = fh
+	return nil
+}

--- a/flock_internal_test.go
+++ b/flock_internal_test.go
@@ -3,28 +3,40 @@ package flock
 import (
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 )
 
 func Test(t *testing.T) {
-	tmpFileFh, err := ioutil.TempFile(os.TempDir(), "go-flock-")
+	pathsToLock := make([]string, 1, 2)
+
+	tmpFileFh, _ := ioutil.TempFile(os.TempDir(), "go-flock-")
 	tmpFileFh.Close()
 	tmpFile := tmpFileFh.Name()
 	os.Remove(tmpFile)
+	pathsToLock[0] = tmpFile
 
-	lock := New(tmpFile)
-	locked, err := lock.TryLock()
-	if locked == false || err != nil {
-		t.Fatalf("failed to lock: locked: %t, err: %v", locked, err)
+	if runtime.GOOS == "linux" {
+		tmpDir, _ := ioutil.TempDir("", "go-flock-")
+		os.Remove(tmpDir)
+		pathsToLock = append(pathsToLock, tmpDir)
 	}
 
-	newLock := New(tmpFile)
-	locked, err = newLock.TryLock()
-	if locked != false || err != nil {
-		t.Fatalf("should have failed locking: locked: %t, err: %v", locked, err)
-	}
+	for _, path := range pathsToLock {
+		lock := New(path)
+		locked, err := lock.TryLock()
+		if locked == false || err != nil {
+			t.Fatalf("failed to lock: locked: %t, err: %v", locked, err)
+		}
 
-	if newLock.fh != nil {
-		t.Fatal("file handle should have been released and be nil")
+		newLock := New(path)
+		locked, err = newLock.TryLock()
+		if locked != false || err != nil {
+			t.Fatalf("should have failed locking: locked: %t, err: %v", locked, err)
+		}
+
+		if newLock.fh != nil {
+			t.Fatal("file handle should have been released and be nil")
+		}
 	}
 }

--- a/flock_test.go
+++ b/flock_test.go
@@ -19,23 +19,30 @@ import (
 )
 
 type TestSuite struct {
+	isdir bool
 	path  string
 	flock *flock.Flock
 }
 
-var _ = Suite(&TestSuite{})
+func Test(t *testing.T) {
+	Suite(new(TestSuite))
+	if runtime.GOOS == "linux" {
+		Suite(&TestSuite{isdir: true})
+	}
 
-func Test(t *testing.T) { TestingT(t) }
+	TestingT(t)
+}
 
 func (t *TestSuite) SetUpTest(c *C) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "go-flock-")
-	c.Assert(err, IsNil)
-	c.Assert(tmpFile, Not(IsNil))
-
-	t.path = tmpFile.Name()
-
-	defer os.Remove(t.path)
-	tmpFile.Close()
+	if t.isdir {
+		tmpDir, err := ioutil.TempDir("", "go-flock-")
+		c.Assert(err, IsNil)
+		t.path = tmpDir
+	} else {
+		tmpFile, err := ioutil.TempFile("", "go-flock-")
+		c.Assert(err, IsNil)
+		t.path = tmpFile.Name()
+	}
 
 	t.flock = flock.New(t.path)
 }

--- a/flock_unix.go
+++ b/flock_unix.go
@@ -195,3 +195,17 @@ func (f *Flock) reopenFDOnError(err error) (bool, error) {
 
 	return false, nil
 }
+
+func (f *Flock) setFh() error {
+	// open a new os.File instance
+	// create it if it doesn't exist, and open the file read-only.
+	flags := os.O_CREATE | os.O_RDONLY
+	fh, err := os.OpenFile(f.path, flags, os.FileMode(0600))
+	if err != nil {
+		return err
+	}
+
+	// set the filehandle on the struct
+	f.fh = fh
+	return nil
+}

--- a/flock_windows.go
+++ b/flock_windows.go
@@ -5,6 +5,7 @@
 package flock
 
 import (
+	"os"
 	"syscall"
 )
 
@@ -139,4 +140,18 @@ func (f *Flock) try(locked *bool, flag uint32) (bool, error) {
 	*locked = true
 
 	return true, nil
+}
+
+func (f *Flock) setFh() error {
+	// open a new os.File instance
+	// create it if it doesn't exist, and open the file read-only.
+	flags := os.O_CREATE | os.O_RDONLY
+	fh, err := os.OpenFile(f.path, flags, os.FileMode(0600))
+	if err != nil {
+		return err
+	}
+
+	// set the filehandle on the struct
+	f.fh = fh
+	return nil
 }


### PR DESCRIPTION
Followup of #39.

Comment from @theckman
> I think to support this, at a minimum, we would need to move the OpenFile error handling code into the platform-specific flock.go files. To quote the proverbs: "Syscall must always be guarded with build tags."

So, I splitted setFh in the system specific files, that should do the trick. I'm unable to test for AIX but windows & linux pass the tests. I've keep the doubling of the main test suite, one with a file, another with a directory.

NB: on master, two examples in `flock_example_test.go` (namely `ExampleFlock_TryLock` & `ExampleFlock_TryLockContext`) are not being run, because of missing `// Output:` line.