### PR TITLE
Added support for Linux on Power on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: go
+arch:
+  - amd64
+  - ppc64le
+
 go:
   - 1.14.x
   - 1.15.x


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/ujjwalsh/flock/builds/194755827
Please have a look.

Regards,
ujjwal