### PR TITLE
try fixing windows file operation failed issue

### DIFF
--- a/flock_windows.go
+++ b/flock_windows.go
@@ -49,7 +49,7 @@ func (f *Flock) lock(locked *bool, flag uint32) error {
 		defer f.ensureFhState()
 	}
 
-	if _, errNo := lockFileEx(syscall.Handle(f.fh.Fd()), flag, 0, 1, 0, &syscall.Overlapped{}); errNo > 0 {
+	if _, errNo := lockFileEx(syscall.Handle(f.fh.Fd()), flag, 0, 0, 0, &syscall.Overlapped{}); errNo > 0 {
 		return errNo
 	}
 
@@ -74,7 +74,7 @@ func (f *Flock) Unlock() error {
 	}
 
 	// mark the file as unlocked
-	if _, errNo := unlockFileEx(syscall.Handle(f.fh.Fd()), 0, 1, 0, &syscall.Overlapped{}); errNo > 0 {
+	if _, errNo := unlockFileEx(syscall.Handle(f.fh.Fd()), 0, 0, 0, &syscall.Overlapped{}); errNo > 0 {
 		return errNo
 	}
 
@@ -126,7 +126,7 @@ func (f *Flock) try(locked *bool, flag uint32) (bool, error) {
 		defer f.ensureFhState()
 	}
 
-	_, errNo := lockFileEx(syscall.Handle(f.fh.Fd()), flag|winLockfileFailImmediately, 0, 1, 0, &syscall.Overlapped{})
+	_, errNo := lockFileEx(syscall.Handle(f.fh.Fd()), flag|winLockfileFailImmediately, 0, 0, 0, &syscall.Overlapped{})
 
 	if errNo > 0 {
 		if errNo == ErrorLockViolation || errNo == syscall.ERROR_IO_PENDING {


### PR DESCRIPTION
https://github.com/golang/go/blob/master/src/cmd/go/internal/lockedfile/internal/filelock/filelock_windows.go
```go
const (
	readLock  lockType = 0
	writeLock lockType = windows.LOCKFILE_EXCLUSIVE_LOCK
)

const (
	reserved = 0
	allBytes = ^uint32(0)
)

func lock(f File, lt lockType) error {
	// Per https://golang.org/issue/19098, “Programs currently expect the Fd
	// method to return a handle that uses ordinary synchronous I/O.”
	// However, LockFileEx still requires an OVERLAPPED structure,
	// which contains the file offset of the beginning of the lock range.
	// We want to lock the entire file, so we leave the offset as zero.
	ol := new(syscall.Overlapped)

	err := windows.LockFileEx(syscall.Handle(f.Fd()), uint32(lt), reserved, allBytes, allBytes, ol)
	if err != nil {
		return &fs.PathError{
			Op:   lt.String(),
			Path: f.Name(),
			Err:  err,
		}
	}
	return nil
}

func unlock(f File) error {
	ol := new(syscall.Overlapped)
	err := windows.UnlockFileEx(syscall.Handle(f.Fd()), reserved, allBytes, allBytes, ol)
	if err != nil {
		return &fs.PathError{
			Op:   "Unlock",
			Path: f.Name(),
			Err:  err,
		}
	}
	return nil
}
```