### PR TITLE
docs: remove reference to sync.Locker

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-BSD_3--Clause-brightgreen.svg?style=flat)](https://github.com/gofrs/flock/blob/master/LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gofrs/flock)](https://goreportcard.com/report/github.com/gofrs/flock)
 
-`flock` implements a thread-safe `sync.Locker` interface for file locking.
+`flock` implements a thread-safe file lock.
 
 It also includes a non-blocking `TryLock()` function to allow locking without blocking execution.
 


### PR DESCRIPTION

The interface `sync.Locker` is:

```go
type Locker interface {
	Lock()
	Unlock()
}
```

https://github.com/golang/go/blob/5a18e79687dea15680ff5f799b549fa0efd0cad9/src/sync/mutex.go#L41-L45

But the method signatures of `Flock` are:
```go
type Foo interface {
	Lock() error
	Unlock() error
}
```

So to implement `sync.Locker` interface, a wrapper should be used.

Example:
```go

type Wrapper struct {
	f *Flock
}

func NewWrapper(path string) *Wrapper {
	return &Wrapper{f: flock.New(path)}
}

func (w Wrapper) Lock() {
	err := w.f.Lock()
	if err != nil {
		panic(err)
	}
}

func (w Wrapper) Unlock() {
	err := w.f.Unlock()
	if err != nil {
		panic(err)
	}
}
```

Fixes #45