### PR TITLE
chore(ci): remove Syscall6 deprecation exclusion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,11 +17,6 @@ issues:
   exclude-use-default: true
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    - path: flock_winapi.go # Should be fixed in the future
-      text: 'SA1019: syscall.Syscall6 has been deprecated since Go 1.18: Use SyscallN instead.'
-      linters:
-        - staticcheck
 
 output:
   show-stats: true


### PR DESCRIPTION
I fixed the problem with `Syscall6` inside 407d4adcd8fed6f3fb745b6b83d93608972435b1 (I wrongly named the commit)