### PR TITLE
tests: remove files generated during tests

### DIFF
--- a/flock.go
+++ b/flock.go
@@ -171,8 +171,10 @@ func (f *Flock) setFh() error {
 
 // ensure the file handle is closed if no lock is held.
 func (f *Flock) ensureFhState() {
-	if !f.l && !f.r && f.fh != nil {
-		f.fh.Close()
-		f.fh = nil
+	if f.l || f.r || f.fh == nil {
+		return
 	}
+
+	f.fh.Close()
+	f.fh = nil
 }

--- a/flock_internal_test.go
+++ b/flock_internal_test.go
@@ -8,27 +8,29 @@ package flock
 import (
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test(t *testing.T) {
-	tmpFileFh, _ := os.CreateTemp(os.TempDir(), "go-flock-")
-	tmpFileFh.Close()
-	tmpFile := tmpFileFh.Name()
-	os.Remove(tmpFile)
+	tmpFile, err := os.CreateTemp(t.TempDir(), "go-flock-")
+	require.NoError(t, err)
 
-	lock := New(tmpFile)
+	tmpFile.Close()
+	os.Remove(tmpFile.Name())
+
+	lock := New(tmpFile.Name())
+
 	locked, err := lock.TryLock()
-	if locked == false || err != nil {
-		t.Fatalf("failed to lock: locked: %t, err: %v", locked, err)
-	}
+	require.NoError(t, err)
+	require.True(t, locked)
 
-	newLock := New(tmpFile)
+	newLock := New(tmpFile.Name())
+
 	locked, err = newLock.TryLock()
-	if locked != false || err != nil {
-		t.Fatalf("should have failed locking: locked: %t, err: %v", locked, err)
-	}
+	require.NoError(t, err)
+	require.False(t, locked)
 
-	if newLock.fh != nil {
-		t.Fatal("file handle should have been released and be nil")
-	}
+	assert.Nil(t, newLock.fh, "file handle should have been released and be nil")
 }

--- a/flock_internal_test.go
+++ b/flock_internal_test.go
@@ -33,4 +33,7 @@ func Test(t *testing.T) {
 	require.False(t, locked)
 
 	assert.Nil(t, newLock.fh, "file handle should have been released and be nil")
+
+	err = lock.Unlock()
+	require.NoError(t, err)
 }

--- a/flock_test.go
+++ b/flock_test.go
@@ -26,7 +26,7 @@ type TestSuite struct {
 func Test(t *testing.T) { suite.Run(t, &TestSuite{}) }
 
 func (s *TestSuite) SetupTest() {
-	tmpFile, err := os.CreateTemp(os.TempDir(), "go-flock-")
+	tmpFile, err := os.CreateTemp(s.T().TempDir(), "go-flock-")
 	s.Require().NoError(err)
 
 	s.Require().NotNil(tmpFile)

--- a/flock_windows.go
+++ b/flock_windows.go
@@ -130,7 +130,6 @@ func (f *Flock) try(locked *bool, flag uint32) (bool, error) {
 	}
 
 	_, errNo := lockFileEx(syscall.Handle(f.fh.Fd()), flag|winLockfileFailImmediately, 0, 1, 0, &syscall.Overlapped{})
-
 	if errNo > 0 {
 		if errNo == ErrorLockViolation || errNo == syscall.ERROR_IO_PENDING {
 			return false, nil


### PR DESCRIPTION
Replaces `os.TempDir()` by `t.TempDir()` to remove the files generated during tests.