### PR TITLE
feat: use runtime errors instead of compilation errors for unusupported platforms

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 # - js/wasm
 # - wasp1/wasm
 
-for row in $(go tool dist list -json | jq -r '.[] | select( .GOOS != "plan9" and .GOARCH != "wasm") | @base64'); do
+for row in $(go tool dist list -json | jq -r '.[] | @base64'); do
   _jq() {
     echo ${row} | base64 --decode | jq -r ${1}
   }

--- a/flock_example_test.go
+++ b/flock_example_test.go
@@ -3,6 +3,8 @@
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
+//go:build !js && !plan9 && !wasip1
+
 package flock_test
 
 import (

--- a/flock_internal_test.go
+++ b/flock_internal_test.go
@@ -3,6 +3,8 @@
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
+//go:build !js && !plan9 && !wasip1
+
 package flock
 
 import (

--- a/flock_others.go
+++ b/flock_others.go
@@ -1,0 +1,40 @@
+//go:build (!unix && !windows) || plan9
+
+package flock
+
+import (
+	"errors"
+	"io/fs"
+)
+
+func (f *Flock) Lock() error {
+	return &fs.PathError{
+		Op:   "Lock",
+		Path: f.Path(),
+		Err:  errors.ErrUnsupported,
+	}
+}
+
+func (f *Flock) RLock() error {
+	return &fs.PathError{
+		Op:   "RLock",
+		Path: f.Path(),
+		Err:  errors.ErrUnsupported,
+	}
+}
+
+func (f *Flock) Unlock() error {
+	return &fs.PathError{
+		Op:   "Unlock",
+		Path: f.Path(),
+		Err:  errors.ErrUnsupported,
+	}
+}
+
+func (f *Flock) TryLock() (bool, error) {
+	return false, f.Lock()
+}
+
+func (f *Flock) TryRLock() (bool, error) {
+	return false, f.RLock()
+}

--- a/flock_test.go
+++ b/flock_test.go
@@ -3,6 +3,8 @@
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
+//go:build !js && !plan9 && !wasip1
+
 package flock_test
 
 import (

--- a/flock_unix.go
+++ b/flock_unix.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
-//go:build !aix && (!solaris || illumos) && !windows
+//go:build darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd
 
 package flock
 

--- a/flock_windows.go
+++ b/flock_windows.go
@@ -3,6 +3,8 @@
 // Use of this source code is governed by the BSD 3-Clause
 // license that can be found in the LICENSE file.
 
+//go:build windows
+
 package flock
 
 import (


### PR DESCRIPTION
Instead of being blocked on unsupported platforms (`*/wasm` and `plan9/*`), `flock` will throught runtime errors.

The errors are:
```go
	return &fs.PathError{
		Op:   "RLock",
		Path: f.Path(),
		Err:  errors.ErrUnsupported,
	}
```

The implementation for unsupported platforms can be added in the future.

Fixes #60