### PR TITLE
chore: remove patch version from go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gofrs/flock
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
relates to https://github.com/gofrs/flock/pull/57#discussion_r1664265710