### PR TITLE
tests: add tests about directory support

### DIFF
--- a/flock_internal_test.go
+++ b/flock_internal_test.go
@@ -9,6 +9,7 @@ package flock
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +33,31 @@ func TestFlock_fh_onError(t *testing.T) {
 	require.True(t, locked)
 
 	newLock := New(tmpFile.Name())
+
+	locked, err = newLock.TryLock()
+	require.NoError(t, err)
+	require.False(t, locked)
+
+	assert.Nil(t, newLock.fh, "file handle should have been released and be nil")
+
+	err = lock.Unlock()
+	require.NoError(t, err)
+}
+
+func TestFlock_fh_onError_dir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("not supported on Windows")
+	}
+
+	tmpDir := t.TempDir()
+
+	lock := New(tmpDir, SetFlag(os.O_RDONLY))
+
+	locked, err := lock.TryLock()
+	require.NoError(t, err)
+	require.True(t, locked)
+
+	newLock := New(tmpDir, SetFlag(os.O_RDONLY))
 
 	locked, err = newLock.TryLock()
 	require.NoError(t, err)


### PR DESCRIPTION
Since the addition of options to define the flag, a directory can be used as a path for the lock.

This doesn't work on Windows.
This has not been tested on AIX, Solaris. 

Closes #49