### PR TITLE
fix: missing read-write flag in reopenFDOnError

### DIFF
--- a/flock.go
+++ b/flock.go
@@ -163,9 +163,9 @@ func tryCtx(ctx context.Context, fn func() (bool, error), retryDelay time.Durati
 	}
 }
 
-func (f *Flock) setFh() error {
+func (f *Flock) setFh(flag int) error {
 	// open a new os.File instance
-	fh, err := os.OpenFile(f.path, f.flag, f.perm)
+	fh, err := os.OpenFile(f.path, flag, f.perm)
 	if err != nil {
 		return err
 	}

--- a/flock_unix.go
+++ b/flock_unix.go
@@ -9,6 +9,7 @@ package flock
 
 import (
 	"errors"
+	"os"
 
 	"golang.org/x/sys/unix"
 )
@@ -198,11 +199,12 @@ func (f *Flock) reopenFDOnError(err error) (bool, error) {
 
 	f.resetFh()
 
-	// reopen the file handle
-	err = f.setFh()
+	// reopen in read-write mode and set the file handle
+	fh, err := os.OpenFile(f.path, f.flag|os.O_RDWR, f.perm)
 	if err != nil {
 		return false, err
 	}
+	f.fh = fh
 
 	return true, nil
 }

--- a/flock_unix.go
+++ b/flock_unix.go
@@ -50,7 +50,7 @@ func (f *Flock) lock(locked *bool, flag int) error {
 	}
 
 	if f.fh == nil {
-		if err := f.setFh(); err != nil {
+		if err := f.setFh(f.flag); err != nil {
 			return err
 		}
 
@@ -147,7 +147,7 @@ func (f *Flock) try(locked *bool, flag int) (bool, error) {
 	}
 
 	if f.fh == nil {
-		if err := f.setFh(); err != nil {
+		if err := f.setFh(f.flag); err != nil {
 			return false, err
 		}
 
@@ -183,6 +183,7 @@ retry:
 // This comes from `util-linux/sys-utils/flock.c`:
 // > Since Linux 3.4 (commit 55725513)
 // > Probably NFSv4 where flock() is emulated by fcntl().
+// > https://github.com/util-linux/util-linux/blob/198e920aa24743ef6ace4e07cf6237de527f9261/sys-utils/flock.c#L374-L390
 func (f *Flock) reopenFDOnError(err error) (bool, error) {
 	if !errors.Is(err, unix.EIO) && !errors.Is(err, unix.EBADF) {
 		return false, nil
@@ -200,11 +201,10 @@ func (f *Flock) reopenFDOnError(err error) (bool, error) {
 	f.resetFh()
 
 	// reopen in read-write mode and set the file handle
-	fh, err := os.OpenFile(f.path, f.flag|os.O_RDWR, f.perm)
+	err = f.setFh(f.flag | os.O_RDWR)
 	if err != nil {
 		return false, err
 	}
-	f.fh = fh
 
 	return true, nil
 }

--- a/flock_unix_fcntl.go
+++ b/flock_unix_fcntl.go
@@ -112,7 +112,7 @@ func (f *Flock) lock(locked *bool, flag lockType) error {
 	}
 
 	if f.fh == nil {
-		if err := f.setFh(); err != nil {
+		if err := f.setFh(f.flag); err != nil {
 			return err
 		}
 
@@ -359,7 +359,7 @@ func (f *Flock) try(locked *bool, flag lockType) (bool, error) {
 	}
 
 	if f.fh == nil {
-		if err := f.setFh(); err != nil {
+		if err := f.setFh(f.flag); err != nil {
 			return false, err
 		}
 

--- a/flock_windows.go
+++ b/flock_windows.go
@@ -56,7 +56,7 @@ func (f *Flock) lock(locked *bool, flag uint32) error {
 	}
 
 	if f.fh == nil {
-		if err := f.setFh(); err != nil {
+		if err := f.setFh(f.flag); err != nil {
 			return err
 		}
 
@@ -136,7 +136,7 @@ func (f *Flock) try(locked *bool, flag uint32) (bool, error) {
 	}
 
 	if f.fh == nil {
-		if err := f.setFh(); err != nil {
+		if err := f.setFh(f.flag); err != nil {
 			return false, err
 		}
 


### PR DESCRIPTION
relates to https://github.com/docker/buildx/issues/2593

seems a regression introduced in https://github.com/gofrs/flock/commit/b659e1e00ac3f430ee58fbfc49f69a9a3b45178c that removes read-write flag: https://github.com/gofrs/flock/commit/b659e1e00ac3f430ee58fbfc49f69a9a3b45178c#diff-87c2c4fe0fb43f4b38b4bee45c1b54cfb694c61e311f93b369caa44f6c1323ffR192

cc @ldez 